### PR TITLE
Bundle Python dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 homebrew-gnuradio
 =================
 
-Delicious and foamy tap of the latest development version of gnuradio! Yay! Builds clean on Mac OS X Yosemite 10.10 using Xcode 6.1 command line tools (clang/llvm).  
+Delicious and foamy tap of the latest development version of gnuradio! Yay! Builds clean on Mac OS X Yosemite 10.10 using Xcode 6.1 command line tools (clang/llvm).
 
 Disable virtualenv if you use it, and:
 
@@ -11,12 +11,12 @@ brew install python
 pip install --upgrade setuptools
 pip install --upgrade pip
 
-pip install numpy -U scipy -U matplotlib -U
+pip install matplotlib -U
 ```
 
 That's all the prepwork, and if you missed a python dependency, while homebrew cannot install it for you, this tap will notice and inform you what dependencies, if any, you need to install using pip.
 
-Anyway, you're ready to 
+Anyway, you're ready to
 ```sh
 brew tap metacollin/gnuradio
 brew install gnuradio --with-qt --with-docs
@@ -26,7 +26,7 @@ and optionally
 brew install librtlsdr #Osmocom rtl-sdr support
 ```
 
-Omit `--with-qt` and `--with-docs` at your descretion.  
+Omit `--with-qt` and `--with-docs` at your descretion.
 
 The latest dev build can be attempted using the `--HEAD` argument, but this isn't necessarily guaranteed to work.
 

--- a/gnuradio.rb
+++ b/gnuradio.rb
@@ -8,14 +8,31 @@ class Gnuradio < Formula
 
   option 'with-qt', 'Build with exta GUI features that use QT'
   option 'with-docs', 'Build gnuradio documentation using sphinx.'
+  option "with-brewed-python", "Use the Homebrew version of Python"
 
+  resource "Cheetah" do
+    url "https://pypi.python.org/packages/source/C/Cheetah/Cheetah-2.4.4.tar.gz"
+    sha1 "c218f5d8bc97b39497680f6be9b7bd093f696e89"
+  end
+
+  resource "lxml" do
+    url "https://pypi.python.org/packages/source/l/lxml/lxml-3.4.1.tar.gz"
+    sha1 "c09f4e8e71fc9d49fb43bf33821da816ce887396"
+  end
+
+  resource "numpy" do
+    url "http://downloads.sourceforge.net/project/numpy/NumPy/1.9.1/numpy-1.9.1.tar.gz"
+    sha1 "a96ddd221b34c08f08ae700a51969ddeb17d40ea"
+  end
+
+  resource "scipy" do
+    url "http://downloads.sourceforge.net/project/scipy/scipy/0.14.0/scipy-0.14.0.tar.gz"
+    sha1 "faf16ddf307eb45ead62a92ffadc5288a710feb8"
+  end
+
+  depends_on :fortran => :build
   depends_on "cmake" => :build
-  depends_on 'Cheetah' => :python
-  depends_on 'lxml' => :python
-  depends_on 'numpy' => :python
-  depends_on 'scipy' => :python
   depends_on 'matplotlib' => :python
-  depends_on 'python'
   depends_on 'boost'
   depends_on 'cppunit'
   depends_on 'gsl'
@@ -35,12 +52,24 @@ class Gnuradio < Formula
     ENV['CMAKE_C_COMPILER'] = '#{ENV.cc}'
     ENV['CMAKE_CXX_COMPILER'] = '#{ENV.cxx}'
 
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
+    python_args = ["install", "--prefix=#{libexec}"]
+    %w[Cheetah lxml].each do |r|
+      resource(r).stage { system "python", "setup.py", *python_args }
+    end
+    python_fortran_args = ["build", "--fcompiler=gnu95", *python_args]
+    %w[numpy scipy].each do |r|
+      resource(r).stage { system "python", "setup.py", *python_fortran_args }
+    end
+
     mkdir 'build' do
       args = %W[
         -DCMAKE_PREFIX_PATH=#{prefix}
         -DENABLE_DOXYGEN=Off
-        -DPYTHON_LIBRARY='#{%x(python-config --prefix).chomp}/lib/libpython2.7.dylib'
-        ] + std_cmake_args
+      ]
+      if build.with? "brewed-python"
+        args << "-DPYTHON_LIBRARY='#{%x(python-config --prefix).chomp}/lib/libpython2.7.dylib'"
+      end
 
       if build.with? "docs"
         args << "-DSPHINX_EXECUTEABLE=/usr/local/bin/rst2html.py"
@@ -55,7 +84,7 @@ class Gnuradio < Formula
       end
 
 
-    system "cmake", "..", *args
+    system "cmake", "..", *args, *std_cmake_args
     system "make"
     system "make install"
   end


### PR DESCRIPTION
The preferred way of handling Python dependencies in Homebrew is to
bundle them in the package's libexec directory.

This change does not include matplotlib due to a build issue which is
still being investigated.
