### PR TITLE
Fix GNU Radio Companion blocks path

### DIFF
--- a/gnuradio.rb
+++ b/gnuradio.rb
@@ -58,6 +58,10 @@ class Gnuradio < Formula
     system "cmake", "..", *args
     system "make"
     system "make install"
+
+      inreplace "#{prefix}/etc/gnuradio/conf.d/grc.conf" do |s|
+        s.gsub! "#{prefix}/", "#{HOMEBREW_PREFIX}/"
+      end
   end
   end
  end


### PR DESCRIPTION
Unless specified, GNU Radio Companion will look for blocks in its
install prefix preventing it from picking up third party blocks
installed on the system.
