### PR TITLE
dependency: GNU Radio depends on docbook

### DIFF
--- a/gnuradio.rb
+++ b/gnuradio.rb
@@ -37,6 +37,7 @@ class Gnuradio < Formula
 
   depends_on :fortran => :build
   depends_on "cmake" => :build
+  depends_on "docbook"
   depends_on "matplotlib" => :python
   depends_on "boost"
   depends_on "cppunit"


### PR DESCRIPTION
It appears the gr-trellis component depends on docbook regardless of
whether the recipe is built with documentation or not.
Fixes #15.