### PR TITLE
Fix typo in brewed-python dependancy list

### DIFF
--- a/gnuradio.rb
+++ b/gnuradio.rb
@@ -45,7 +45,7 @@ class Gnuradio < Formula
   depends_on :fortran => :build
   depends_on "cmake" => :build
   if build.with? "brewed-python"
-    deponds_on "matplotlib" => :python
+    depends_on "matplotlib" => :python
   end
   depends_on "boost"
   depends_on "cppunit"


### PR DESCRIPTION
Fix for a small typo that breaks the brewed-python option.