### PR TITLE
Fix typo which breaks build

### DIFF
--- a/gnuradio.rb
+++ b/gnuradio.rb
@@ -45,7 +45,7 @@ class Gnuradio < Formula
   depends_on :fortran => :build
   depends_on "cmake" => :build
   if build.with? "brewed-python"
-    deponds_on "matplotlib" => :python
+    depends_on "matplotlib" => :python
   end
   depends_on "boost"
   depends_on "cppunit"


### PR DESCRIPTION
When installing with brewed python... a typo kills install.  Here's a pr which fixes the issue